### PR TITLE
Fix type names in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,16 +20,16 @@ The library is usable and nearly complete, but needs polish.
 
 ## API Overview
 
-All parser state is attached to a `json_stream_t` struct. Its fields
+All parser state is attached to a `json_stream` struct. Its fields
 should not be accessed directly. To initialize, it can be "opened" on
 an input `FILE *` stream or memory buffer. It's disposed of by being
 "closed."
 
 ~~~c
-void json_open_stream(json_stream_t *json, FILE * stream);
-void json_open_string(json_stream_t *json, const char *string);
-void json_open_buffer(json_stream_t *json, const void *buffer, size_t size);
-void json_close(json_stream_t *json);
+void json_open_stream(json_stream *json, FILE * stream);
+void json_open_string(json_stream *json, const char *string);
+void json_open_buffer(json_stream *json, const void *buffer, size_t size);
+void json_close(json_stream *json);
 ~~~
 
 By default only one value is read from the stream. The parser can be
@@ -37,7 +37,7 @@ reset to read more objects. The overall line number and position are
 preserved.
 
 ~~~c
-void json_reset(json_stream_t *json);
+void json_reset(json_stream *json);
 ~~~
 
 The JSON is parsed as a stream of events (`enum json_type`). The
@@ -45,11 +45,11 @@ stream is in the indicated state, during which data can be queried and
 retrieved.
 
 ~~~c
-enum json_type json_next(json_stream_t *json);
-enum json_type json_peek(json_stream_t *json);
+enum json_type json_next(json_stream *json);
+enum json_type json_peek(json_stream *json);
 
-const char *json_get_string(json_stream_t *json, size_t *length);
-double json_get_number(json_stream_t *json);
+const char *json_get_string(json_stream *json, size_t *length);
+double json_get_number(json_stream *json);
 ~~~
 
 Numbers can also be retrieved by `json_get_string()`, which will
@@ -63,9 +63,9 @@ as the line number and byte position. (The line number and byte
 position are always available.)
 
 ~~~c
-const char *json_get_error(json_stream_t *json);
-size_t json_get_lineno(json_stream_t *json);
-size_t json_get_position(json_stream_t *json);
+const char *json_get_error(json_stream *json);
+size_t json_get_lineno(json_stream *json);
+size_t json_get_position(json_stream *json);
 ~~~
 
 Outside of errors, a `JSON_OBJECT` event will always be followed by


### PR DESCRIPTION
96b32a9ed117dd4d47f7446bb42dfad632e15a73 dropped `_t` suffixes from the
`json_stream` typedef, but didn't update API usage in the README.