### PR TITLE
json: allow custom allocator; improve stack semantics

### DIFF
--- a/json.h
+++ b/json.h
@@ -9,13 +9,21 @@ enum json_type {
     JSON_STRING, JSON_NUMBER, JSON_TRUE, JSON_FALSE, JSON_NULL
 };
 
+struct json_allocator {
+    void *(*malloc)(size_t);
+    void *(*realloc)(void *, size_t);
+    void (*free)(void *);
+};
+
 #include "json_private.h"
 
 typedef struct json_stream json_stream;
+typedef struct json_allocator json_allocator;
 
 void json_open_buffer(json_stream *json, const void *buffer, size_t size);
 void json_open_string(json_stream *json, const char *string);
-void json_open_stream(json_stream *json, FILE * stream);
+void json_open_stream(json_stream *json, FILE *stream);
+void json_set_allocator(json_stream *json, json_allocator *a);
 void json_close(json_stream *json);
 
 enum json_type json_next(json_stream *json);

--- a/json_private.h
+++ b/json_private.h
@@ -18,18 +18,31 @@ struct json_source {
     } source;
 };
 
+struct json_stack {
+    enum json_type type;
+    long count;
+};
+
 struct json_stream {
     size_t lineno;
-    int error;
-    char errmsg[128];
+
+    struct json_stack *stack;
+    int_least32_t stack_top;
+    int_least32_t stack_size;
     enum json_type next;
-    struct nesting *nesting;
+    int error;
+
     struct {
         char *string;
-        size_t string_fill, string_size;
+        size_t string_fill;
+        size_t string_size;
     } data;
+
     size_t ntokens;
+
     struct json_source source;
+    struct json_allocator alloc;
+    char errmsg[128];
 };
 
 #endif


### PR DESCRIPTION
Allocating and freeing a bunch of tiny structures for a stack and
strings can be costly from a performance perspective (as can relying on
the sytem allocator). This change allows consumers to specify their own
allocation functions.

This change also removes unused / unnecessary fields from the "nesting"
struct, and renames it to `struct json_stack`. This struct is now
embedded in `json_stream`, and functions as an array. The stack is grown
four elements at a time (which is ~1 cache line on many modern
architectures) because magic numbers are hard. The stack is now treated
as an array with a size and a pointer to the stack top, instead of being
a linked list.

When exiting from a particular nesting, we do not free or realloc to a
smaller size. Most JSON streams I've encountered are not terribly deep,
and those that are tend to have a relatively constant depth. In other
words, deep JSON data structures likely have pessimistic allocation
patterns; it's best to just reuse the memory. At 16 bytes per nesting
level, you really have to try hard to make this actually be a waste of
memory.

I've also reordered the `json_stream` structure a bit to try to keep
related data close. On architectures with 64B cache lines, `json_stream`
now takes 4, but all the common mutable data is in 1 while the read-only
stuff is elsewhere.