### PR TITLE
json: fix invalid behavior per JSONTestSuite

### DIFF
--- a/json.h
+++ b/json.h
@@ -25,6 +25,7 @@ void json_open_string(json_stream *json, const char *string);
 void json_open_stream(json_stream *json, FILE *stream);
 void json_set_allocator(json_stream *json, json_allocator *a);
 void json_close(json_stream *json);
+void json_set_strict(json_stream *json, bool strict);
 
 enum json_type json_next(json_stream *json);
 enum json_type json_peek(json_stream *json);

--- a/json_private.h
+++ b/json_private.h
@@ -1,6 +1,7 @@
 #ifndef PDJSON_PRIVATE_H
 #define PDJSON_PRIVATE_H
 
+#include <stdbool.h>
 #include <stdio.h>
 
 struct json_source {
@@ -30,7 +31,8 @@ struct json_stream {
     size_t stack_top;
     size_t stack_size;
     enum json_type next;
-    int error;
+    int error : 31;
+    bool strict : 1;
 
     struct {
         char *string;


### PR DESCRIPTION
After this commit, the test suite at

https://github.com/nst/JSONTestSuite

reports no issues that aren't understood to be implementation-defined
behavior, meaning pdjson is the only C JSON parser that passes all tests
it is supposed to pass, and fails all tests it is supposed to fail. (At
least of the ones tested by JSONTestSuite.)

There remains ambiguity in various unspecified behaviors largely around
handling of unescaped UTF literals that are invalid or denote
surrogates, and various issues with subnormal numbers,
overflow/underflow, and issues of that ilk. In general, I would like to
error on those issues, but they aren't really pressing to me.

This commit introduces a "strict" mode which causes an error when
non-whitespace data trails the outermost value. This is not the default
mode because it prevents a consumer from parsing a stream of JSON with
no whitespace between the containers.