### PR TITLE
Change "strict" to "streaming" and document new API stuff

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,8 @@ more, no less, so that even slightly non-conforming JSON is rejected.
 The input is assumed to be UTF-8, and all strings returned by the
 library are UTF-8 with possible nul characters in the middle, which is
 why the size output parameter is important. Encoded characters
-(`\uxxxx`) are decoded and re-encoded into UTF-8.
+(`\uxxxx`) are decoded and re-encoded into UTF-8. UTF-16 surrogate
+pairs expressed as adjacent encoded characters are supported.
 
 One exception to this rule is made to support a "streaming" mode. When
 a JSON "stream" contains multiple JSON objects (optionally separated

--- a/README.md
+++ b/README.md
@@ -30,18 +30,18 @@ should not be accessed directly. To initialize, it can be "opened" on
 an input `FILE *` stream or memory buffer. It's disposed of by being
 "closed."
 
-~~~c
+```c
 void json_open_stream(json_stream *json, FILE * stream);
 void json_open_string(json_stream *json, const char *string);
 void json_open_buffer(json_stream *json, const void *buffer, size_t size);
 void json_close(json_stream *json);
-~~~
+```
 
 After opening a stream, custom allocator callbacks can be specified,
 in case allocations should not come from a system-supplied malloc.
 (When no custom allocator is specified, the system allocator is used.)
 
-~~~c
+```c
 struct json_allocator {
     void *(*malloc)(size_t);
     void *(*realloc)(void *, size_t);
@@ -50,36 +50,36 @@ struct json_allocator {
 
 
 void json_set_allocator(json_stream *json, json_allocator *a);
-~~~
+```
 
 By default only one value is read from the stream. The parser can be
 reset to read more objects. The overall line number and position are
 preserved.
 
-~~~c
+```c
 void json_reset(json_stream *json);
-~~~
+```
 
 If strict conformance to the JSON standard is desired, streaming mode
 can be disabled by calling `json_set_streaming` and setting the mode to
 `false`. This will cause any non-whitespace trailing data to trigger a
 parse error.
 
-~~~c
+```c
 void json_set_streaming(json_stream *json, bool mode);
-~~~
+```
 
 The JSON is parsed as a stream of events (`enum json_type`). The
 stream is in the indicated state, during which data can be queried and
 retrieved.
 
-~~~c
+```c
 enum json_type json_next(json_stream *json);
 enum json_type json_peek(json_stream *json);
 
 const char *json_get_string(json_stream *json, size_t *length);
 double json_get_number(json_stream *json);
-~~~
+```
 
 Numbers can also be retrieved by `json_get_string()`, which will
 return the raw text number as it appeared in the JSON. This is useful
@@ -91,11 +91,11 @@ error, a human-friendly, English error message is available, as well
 as the line number and byte position. (The line number and byte
 position are always available.)
 
-~~~c
+```c
 const char *json_get_error(json_stream *json);
 size_t json_get_lineno(json_stream *json);
 size_t json_get_position(json_stream *json);
-~~~
+```
 
 Outside of errors, a `JSON_OBJECT` event will always be followed by
 zero or more pairs of `JSON_STRING` (property name) events and their

--- a/json.c
+++ b/json.c
@@ -93,7 +93,7 @@ static void init(json_stream *json)
     json->errmsg[0] = '\0';
     json->ntokens = 0;
     json->next = 0;
-    json->strict = 0;
+    json->streaming = true;
 
     json->stack = NULL;
     json->stack_top = -1;
@@ -371,7 +371,7 @@ read_digits(json_stream *json)
         nread++;
     }
 
-    if (json->strict && nread == 0) {
+    if (nread == 0) {
         return -1;
     }
 
@@ -529,7 +529,7 @@ enum json_type json_next(json_stream *json)
             }
         } while (json_isspace(c));
 
-        if (json->strict && c != EOF) {
+        if (!json->streaming && c != EOF) {
             return JSON_ERROR;
         }
 
@@ -672,9 +672,9 @@ void json_set_allocator(json_stream *json, json_allocator *a)
     json->alloc = *a;
 }
 
-void json_set_strict(json_stream *json, bool strict)
+void json_set_streaming(json_stream *json, bool streaming)
 {
-    json->strict = strict;
+    json->streaming = streaming;
 }
 
 void json_close(json_stream *json)

--- a/json.h
+++ b/json.h
@@ -23,9 +23,10 @@ typedef struct json_allocator json_allocator;
 void json_open_buffer(json_stream *json, const void *buffer, size_t size);
 void json_open_string(json_stream *json, const char *string);
 void json_open_stream(json_stream *json, FILE *stream);
-void json_set_allocator(json_stream *json, json_allocator *a);
 void json_close(json_stream *json);
-void json_set_strict(json_stream *json, bool strict);
+
+void json_set_allocator(json_stream *json, json_allocator *a);
+void json_set_streaming(json_stream *json, bool strict);
 
 enum json_type json_next(json_stream *json);
 enum json_type json_peek(json_stream *json);

--- a/json_private.h
+++ b/json_private.h
@@ -32,7 +32,7 @@ struct json_stream {
     size_t stack_size;
     enum json_type next;
     int error : 31;
-    bool strict : 1;
+    bool streaming : 1;
 
     struct {
         char *string;


### PR DESCRIPTION
This set of commits changes the "strict" mode to "streaming" mode such that the only default behavior deviating from the standard is supporting multiple valid JSON values in a stream.

It also documents the new APIs introduced (streaming mode, custom allocators), uses backticks for code formatting in the README, and adds some notes on support for UTF-16 surrogate pairs.