### PR TITLE
Added support for user I/O functions, wrap public header in extern "C"

### DIFF
--- a/json.c
+++ b/json.c
@@ -800,6 +800,26 @@ void json_open_stream(json_stream *json, FILE * stream)
     json->source.source.stream.stream = stream;
 }
 
+static int user_get(struct json_source *json)
+{
+    return json->source.user.get(json->source.user.ptr);
+}
+
+static int user_peek(struct json_source *json)
+{
+    return json->source.user.peek(json->source.user.ptr);
+}
+
+void json_open_user(json_stream *json, json_user_io get, json_user_io peek, void *user)
+{
+    init(json);
+    json->source.get = user_get;
+    json->source.peek = user_peek;
+    json->source.source.user.ptr = user;
+    json->source.source.user.get = get;
+    json->source.source.user.peek = peek;
+}
+
 void json_set_allocator(json_stream *json, json_allocator *a)
 {
     json->alloc = *a;

--- a/json.h
+++ b/json.h
@@ -1,6 +1,10 @@
 #ifndef PDJSON_H
 #define PDJSON_H
 
+#ifdef __cplusplus
+extern "C" {
+#endif // __cplusplus
+
 #include <stdio.h>
 
 enum json_type {
@@ -15,6 +19,8 @@ struct json_allocator {
     void (*free)(void *);
 };
 
+typedef int (*json_user_io) (void *user);
+
 #include "json_private.h"
 
 typedef struct json_stream json_stream;
@@ -23,6 +29,7 @@ typedef struct json_allocator json_allocator;
 void json_open_buffer(json_stream *json, const void *buffer, size_t size);
 void json_open_string(json_stream *json, const char *string);
 void json_open_stream(json_stream *json, FILE *stream);
+void json_open_user(json_stream *json, json_user_io get, json_user_io peek, void *user);
 void json_close(json_stream *json);
 
 void json_set_allocator(json_stream *json, json_allocator *a);
@@ -38,5 +45,9 @@ size_t json_get_lineno(json_stream *json);
 size_t json_get_position(json_stream *json);
 size_t json_get_depth(json_stream *json);
 const char *json_get_error(json_stream *json);
+
+#ifdef __cplusplus
+} // extern "C"
+#endif // __cplusplus
 
 #endif

--- a/json_private.h
+++ b/json_private.h
@@ -16,6 +16,11 @@ struct json_source {
             const char *buffer;
             size_t length;
         } buffer;
+        struct {
+            void *ptr;
+            json_user_io get;
+            json_user_io peek;
+        } user;
     } source;
 };
 


### PR DESCRIPTION
This PR allows users to pass in custom I/O functions. I use it to directly read JSON from a Poco socket. It also relieves C++ users of the burden of having to wrap the **#include** in **extern "C"**.