### PR TITLE
c90 compile changes; c99 compiles cleanly; all tests pass (few questions #12)

### DIFF
--- a/pdjson.h
+++ b/pdjson.h
@@ -4,8 +4,16 @@
 #ifdef __cplusplus
 extern "C" {
 #else
-#include <stdbool.h>
-#endif // __cplusplus
+#if defined(__STDC_VERSION__) || (__STDC_VERSION__ >= 199901L)
+    #include <stdbool.h>
+#else
+    #ifndef bool
+        #define bool int
+        #define true 1
+        #define false 0
+    #endif /* bool */
+#endif /* __STDC_VERSION__ */
+#endif /* __cplusplus */
 
 #include <stdio.h>
 
@@ -91,7 +99,7 @@ struct json_stream {
 };
 
 #ifdef __cplusplus
-} // extern "C"
-#endif // __cplusplus
+} /* extern "C" */
+#endif /* __cplusplus */
 
 #endif

--- a/pdjson.h
+++ b/pdjson.h
@@ -4,7 +4,7 @@
 #ifdef __cplusplus
 extern "C" {
 #else
-#if defined(__STDC_VERSION__) || (__STDC_VERSION__ >= 199901L)
+#if defined(__STDC_VERSION__) && (__STDC_VERSION__ >= 199901L)
     #include <stdbool.h>
 #else
     #ifndef bool

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -268,7 +268,7 @@ main(void)
         /* This is a valid encoding for U+10000 */
         const char str[] = "\":\\uD800\\uDC00\"";
         struct expect seq[] = {
-            {JSON_STRING, ":\xf0\x90\x80\x80"}, // UTF-8 for U+10000
+            {JSON_STRING, ":\xf0\x90\x80\x80"}, /* UTF-8 for U+10000 */
             {JSON_DONE},
         };
         TEST("surrogate pair", false);


### PR DESCRIPTION
@skeeto this compiles cleanly and all tests pass with -std=c99
-std=c90 is hit-n-miss, but this is enough for our needs - we compile with -c99, but with bool we're still hitting that grey zone of compilers versions where c99 support was incomplete

in any case, thanks a lot for responsiveness and if this is too much for your taste, no hard feelings :)