### PR TITLE
Add json_skip and json_skip_until

### DIFF
--- a/pdjson.h
+++ b/pdjson.h
@@ -49,6 +49,9 @@ void json_reset(json_stream *json);
 const char *json_get_string(json_stream *json, size_t *length);
 double json_get_number(json_stream *json);
 
+enum json_type json_skip(json_stream *json);
+enum json_type json_skip_until(json_stream *json, enum json_type type);
+
 size_t json_get_lineno(json_stream *json);
 size_t json_get_position(json_stream *json);
 size_t json_get_depth(json_stream *json);


### PR DESCRIPTION
I use these functions in my project and I think they should be part of the library.

`json_skip_until` is useful when parsing JSON via `json_next` in a loop, and there's a need to skip `JSON_OBJECT` or `JSON_ARRAY` completely with all their children. 

In that case one should call:
````C
json_skip_until(json, JSON_ARRAY_END);
````
or
````C
json_skip_until(json, JSON_OBJECT_END);
````

---
`json_skip` is used inside `json_skip_until`, but also can be useful as a standalone function.
For `JSON_OBJECT` and `JSON_ARRAY` it just skips them with all their children, for other types it is the same as `json_next`.

---
Both these functions return immediately on `JSON_DONE` and `JSON_ERROR`.