### PR TITLE
Fix `-Wimplicit-fallthrough` warnings that seem to be new in GCC-7+

### DIFF
--- a/pdjson.c
+++ b/pdjson.c
@@ -399,8 +399,10 @@ is_legal_utf8(const unsigned char *bytes, int length)
         // Everything else falls through when true.
     case 4:
         if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0;
+        /* FALLTHRU */
     case 3:
         if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0;
+        /* FALLTHRU */
     case 2:
         a = (*--srcptr);
         switch (*bytes)
@@ -419,6 +421,7 @@ is_legal_utf8(const unsigned char *bytes, int length)
             break;
         default:
             if (a < 0x80 || a > 0xBF) return 0;
+            break;
         }
     case 1:
         if (*bytes >= 0x80 && *bytes < 0xC2) return 0;


### PR DESCRIPTION
With GCC-7, the `CFLAGS` defined in the `Makefile` now detect warnings in `pdjson.c`. According to the [GCC manual](https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html#index-Wimplicit-fallthrough) on the warning, a comment right before the following `case` statement that is `/* FALLTHRU */` can be used to inform the compiler that the fall-through is intentional.

There are three cases in the `is_legal_utf8` function that use fall-through of some sort. Two can be fixed with the comment and one can be fixed by making an implicit `break` an explicit one.

For reference, this is the output on my Ubuntu 16.04.6 LTS machine after installing gcc-7 and running `make CC=gcc-7`.

```
gcc-7 -c -std=c99 -pedantic -Wall -Wextra -Wno-missing-field-initializers -o pdjson.o pdjson.c
pdjson.c: In function ‘is_legal_utf8’:
pdjson.c:401:38: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0;
             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
pdjson.c:403:5: note: here
     case 3:
     ^~~~
pdjson.c:404:38: warning: this statement may fall through [-Wimplicit-fallthrough=]
         if ((a = (*--srcptr)) < 0x80 || a > 0xBF) return 0;
             ~~~~~~~~~~~~~~~~~~~~~~~~~^~~~~~~~~~~
pdjson.c:406:5: note: here
     case 2:
     ^~~~
pdjson.c:423:26: warning: this statement may fall through [-Wimplicit-fallthrough=]
             if (a < 0x80 || a > 0xBF) return 0;
                 ~~~~~~~~~^~~~~~~~~~~
pdjson.c:426:5: note: here
     case 1:
     ^~~~
```