### PR TITLE
Use RFC8259 terminology in diagnostics and documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,6 +99,6 @@ size_t json_get_position(json_stream *json);
 ```
 
 Outside of errors, a `JSON_OBJECT` event will always be followed by
-zero or more pairs of `JSON_STRING` (property name) events and their
+zero or more pairs of `JSON_STRING` (member name) events and their
 associated value events. That is, the stream of events will always be
 logical and consistent.


### PR DESCRIPTION
Also clean up a few stylistic and formatting inconsistencies.

Terminology-wise, these are the key changes:

```
"property name/value"  ->  "member name/value"
"data"                 ->  "text"               (RFC calls it "JSON text")
```

Fixes issue #21.