### PR TITLE
Streaming mode improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,3 +106,35 @@ logical and consistent.
 In the streaming mode the end of the input is indicated by returning a second
 `JSON_DONE` event. Note also that in this mode an input consisting of zero
 JSON values is valid and is represented by a single `JSON_DONE` event.
+
+JSON values in the stream can be separated by zero or more JSON whitespaces.
+Stricter or alternative separation can be implemented by reading and analyzing
+characters between values using the following functions.
+
+```c
+int json_source_get (json_stream *json);
+int json_source_peek (json_stream *json);
+bool json_isspace(int c);
+```
+
+As an example, the following code fragment makes sure values are separated by
+at least one newline.
+
+```c
+enum json_type e = json_next(json);
+
+if (e == JSON_DONE) {
+    int c = '\0';
+    while (json_isspace(c = json_source_peek(json))) {
+        json_source_get(json);
+        if (c == '\n')
+            break;
+    }
+
+    if (c != '\n' && c != EOF) {
+        /* error */
+    }
+
+    json_reset(json);
+}
+```

--- a/README.md
+++ b/README.md
@@ -102,3 +102,7 @@ Outside of errors, a `JSON_OBJECT` event will always be followed by
 zero or more pairs of `JSON_STRING` (member name) events and their
 associated value events. That is, the stream of events will always be
 logical and consistent.
+
+In the streaming mode the end of the input is indicated by returning a second
+`JSON_DONE` event. Note also that in this mode an input consisting of zero
+JSON values is valid and is represented by a single `JSON_DONE` event.

--- a/pdjson.c
+++ b/pdjson.c
@@ -710,8 +710,12 @@ enum json_type json_next(json_stream *json)
         return JSON_DONE;
     }
     int c = next(json);
-    if (json->stack_top == (size_t)-1)
+    if (json->stack_top == (size_t)-1) {
+        if (c == EOF && (json->flags & JSON_FLAG_STREAMING))
+            return JSON_DONE;
+
         return read_value(json, c);
+    }
     if (json->stack[json->stack_top].type == JSON_ARRAY) {
         if (json->stack[json->stack_top].count == 0) {
             if (c == ']') {

--- a/pdjson.h
+++ b/pdjson.h
@@ -62,6 +62,10 @@ PDJSON_SYMEXPORT size_t json_get_depth(json_stream *json);
 PDJSON_SYMEXPORT enum json_type json_get_context(json_stream *json, size_t *count);
 PDJSON_SYMEXPORT const char *json_get_error(json_stream *json);
 
+PDJSON_SYMEXPORT int json_source_get (json_stream *json);
+PDJSON_SYMEXPORT int json_source_peek (json_stream *json);
+PDJSON_SYMEXPORT bool json_isspace(int c);
+
 /* internal */
 
 struct json_source {

--- a/tests/stream.c
+++ b/tests/stream.c
@@ -25,13 +25,10 @@ main(void)
     json_open_stream(s, stdin);
     json_set_streaming(s, 1);
     puts("struct expect seq[] = {");
-    for (;;) {
+    for (bool first = true;;) {
         enum json_type type = json_next(s);
         const char *value = 0;
         switch (type) {
-            case JSON_DONE:
-                json_reset(s);
-                break;
             case JSON_NULL:
                 value = "null";
                 break;
@@ -52,6 +49,7 @@ main(void)
             case JSON_OBJECT_END:
             case JSON_ARRAY_END:
             case JSON_ERROR:
+            case JSON_DONE:
                 break;
         }
         if (value)
@@ -60,6 +58,13 @@ main(void)
             printf("    {JSON_%s},\n", json_typename[type]);
         if (type == JSON_ERROR)
             break;
+        if (type == JSON_DONE) {
+            if (first)
+                break;
+            json_reset(s);
+            first = true;
+        } else
+            first = false;
     }
     puts("};");
     json_close(s);

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -189,7 +189,7 @@ main(void)
             {JSON_DONE},
             {JSON_NUMBER, "2002"},
             {JSON_DONE},
-            {JSON_ERROR},
+            {JSON_DONE},
         };
         TEST("number stream", true);
     }
@@ -211,9 +211,17 @@ main(void)
             {JSON_DONE},
             {JSON_STRING, "name"},
             {JSON_DONE},
-            {JSON_ERROR},
+            {JSON_DONE},
         };
         TEST("mixed stream", true);
+    }
+
+    {
+        const char str[] = " \n";
+        struct expect seq[] = {
+            {JSON_DONE},
+        };
+        TEST("empty stream", true);
     }
 
     {


### PR DESCRIPTION
I've implemented a fix for issue #22 as well as the ability to implement custom value separation in the streaming mode as discussed in PR #19.

Both changes have been tested with the LLVM fuzzer in addition to the normal tests.