### PR TITLE
Add support for column numbers (and a few fixes)

### DIFF
--- a/pdjson.c
+++ b/pdjson.c
@@ -472,11 +472,14 @@ read_utf8(json_stream* json, int next_char)
     int i;
     for (i = 1; i < count; ++i)
     {
-        if ((buffer[i] = json->source.get(&json->source)) != EOF)
-            json->lineadj++;
+        if ((next_char = json->source.get(&json->source)) == EOF)
+            break;
+
+        buffer[i] = next_char;
+        json->lineadj++;
     }
 
-    if (!is_legal_utf8((unsigned char*) buffer, count))
+    if (i != count || !is_legal_utf8((unsigned char*) buffer, count))
     {
         json_error(json, "%s", "invalid UTF-8 text");
         return -1;

--- a/pdjson.c
+++ b/pdjson.c
@@ -465,7 +465,7 @@ read_utf8(json_stream* json, int next_char)
     int i;
     for (i = 1; i < count; ++i)
     {
-        buffer[i] = json->source.get(&json->source);;
+        buffer[i] = json->source.get(&json->source);
     }
 
     if (!is_legal_utf8((unsigned char*) buffer, count))

--- a/pdjson.c
+++ b/pdjson.c
@@ -101,14 +101,17 @@ static int buffer_peek(struct json_source *source)
 static int buffer_get(struct json_source *source)
 {
     int c = source->peek(source);
-    source->position++;
+    if (c != EOF)
+        source->position++;
     return c;
 }
 
 static int stream_get(struct json_source *source)
 {
-    source->position++;
-    return fgetc(source->source.stream.stream);
+    int c = fgetc(source->source.stream.stream);
+    if (c != EOF)
+        source->position++;
+    return c;
 }
 
 static int stream_peek(struct json_source *source)
@@ -927,7 +930,10 @@ void json_open_stream(json_stream *json, FILE * stream)
 
 static int user_get(struct json_source *json)
 {
-    return json->source.user.get(json->source.user.ptr);
+    int c = json->source.user.get(json->source.user.ptr);
+    if (c != EOF)
+        json->position++;
+    return c;
 }
 
 static int user_peek(struct json_source *json)

--- a/pdjson.c
+++ b/pdjson.c
@@ -124,6 +124,10 @@ static int stream_peek(struct json_source *source)
 static void init(json_stream *json)
 {
     json->lineno = 1;
+    json->linepos = 0;
+    json->lineadj = 0;
+    json->linecon = 0;
+    json->colno = 0;
     json->flags = JSON_FLAG_STREAMING;
     json->errmsg[0] = '\0';
     json->ntokens = 0;
@@ -468,7 +472,8 @@ read_utf8(json_stream* json, int next_char)
     int i;
     for (i = 1; i < count; ++i)
     {
-        buffer[i] = json->source.get(&json->source);
+        if ((buffer[i] = json->source.get(&json->source)) != EOF)
+            json->lineadj++;
     }
 
     if (!is_legal_utf8((unsigned char*) buffer, count))
@@ -597,6 +602,7 @@ read_number(json_stream *json, int c)
             if (read_digits(json) != 0)
                 return JSON_ERROR;
         } else {
+            json->source.get(&json->source); // consume (for column)
             json_error(json, "unexpected byte '%c' in number", c);
             return JSON_ERROR;
         }
@@ -621,36 +627,59 @@ json_isspace(int c)
     return false;
 }
 
-/* Returns the next non-whitespace character in the stream. */
+static void newline(json_stream *json)
+{
+    json->lineno++;
+    json->linepos = json->source.position;
+    json->lineadj = 0;
+    json->linecon = 0;
+}
+
+/* Returns the next non-whitespace character in the stream.
+ *
+ * Note that this is the only function (besides user-facing json_source_get())
+ * that needs to worry about newline housekeeping.
+ */
 static int next(json_stream *json)
 {
    int c;
    while (json_isspace(c = json->source.get(&json->source)))
        if (c == '\n')
-           json->lineno++;
+           newline(json);
    return c;
 }
 
 static enum json_type
 read_value(json_stream *json, int c)
 {
+    enum json_type type;
+    size_t colno = json_get_column(json);
+
     json->ntokens++;
+
     switch (c) {
     case EOF:
         json_error(json, "%s", "unexpected end of text");
-        return JSON_ERROR;
+        type = JSON_ERROR;
+        break;
     case '{':
-        return push(json, JSON_OBJECT);
+        type = push(json, JSON_OBJECT);
+        break;
     case '[':
-        return push(json, JSON_ARRAY);
+        type = push(json, JSON_ARRAY);
+        break;
     case '"':
-        return read_string(json);
+        type = read_string(json);
+        break;
     case 'n':
-        return is_match(json, "ull", JSON_NULL);
+        type = is_match(json, "ull", JSON_NULL);
+        break;
     case 'f':
-        return is_match(json, "alse", JSON_FALSE);
+        type = is_match(json, "alse", JSON_FALSE);
+        break;
     case 't':
-        return is_match(json, "rue", JSON_TRUE);
+        type = is_match(json, "rue", JSON_TRUE);
+        break;
     case '0':
     case '1':
     case '2':
@@ -662,13 +691,18 @@ read_value(json_stream *json, int c)
     case '8':
     case '9':
     case '-':
-        if (init_string(json) != 0)
-            return JSON_ERROR;
-        return read_number(json, c);
+        type = init_string(json) == 0 ? read_number(json, c) : JSON_ERROR;
+        break;
     default:
+        type = JSON_ERROR;
         json_error(json, "unexpected byte '%c' in value", c);
-        return JSON_ERROR;
+        break;
     }
+
+    if (type != JSON_ERROR)
+        json->colno = colno;
+
+    return type;
 }
 
 enum json_type json_peek(json_stream *json)
@@ -690,6 +724,9 @@ enum json_type json_next(json_stream *json)
         json->next = (enum json_type)0;
         return next;
     }
+
+    json->colno = 0;
+
     if (json->ntokens > 0 && json->stack_top == (size_t)-1) {
 
         /* In the streaming mode leave any trailing whitespaces in the stream.
@@ -698,15 +735,7 @@ enum json_type json_next(json_stream *json)
          * remaining whitespaces ignored as leading when we parse the next
          * value. */
         if (!(json->flags & JSON_FLAG_STREAMING)) {
-            int c;
-
-            do {
-                c = json->source.peek(&json->source);
-                if (json_isspace(c)) {
-                    c = json->source.get(&json->source);
-                }
-            } while (json_isspace(c));
-
+            int c = next(json);
             if (c != EOF) {
                 json_error(json, "expected end of text instead of byte '%c'", c);
                 return JSON_ERROR;
@@ -868,6 +897,13 @@ size_t json_get_position(json_stream *json)
     return json->source.position;
 }
 
+size_t json_get_column(json_stream *json)
+{
+    return json->colno == 0
+               ? json->source.position - json->linepos - json->lineadj
+               : json->colno;
+}
+
 size_t json_get_depth(json_stream *json)
 {
     return json->stack_top + 1;
@@ -895,9 +931,22 @@ enum json_type json_get_context(json_stream *json, size_t *count)
 
 int json_source_get(json_stream *json)
 {
+    /* If the caller reads a multi-byte UTF-8 sequence, we expect them to read
+     * it in its entirety. We also assume that any invalid bytes within such a
+     * sequence belong to the same column (as opposed to starting a new column
+     * or some such). */
+
     int c = json->source.get(&json->source);
-    if (c == '\n')
-        json->lineno++;
+    if (json->linecon > 0) {
+        /* Expecting a continuation byte within a multi-byte UTF-8 sequence. */
+        json->linecon--;
+        if (c != EOF)
+            json->lineadj++;
+    } else if (c == '\n')
+        newline(json);
+    else if (c >= 0xC2 && c <= 0xF4) /* First in multi-byte UTF-8 sequence. */
+        json->linecon = utf8_seq_length(c) - 1;
+
     return c;
 }
 

--- a/pdjson.c
+++ b/pdjson.c
@@ -900,7 +900,7 @@ size_t json_get_position(json_stream *json)
 size_t json_get_column(json_stream *json)
 {
     return json->colno == 0
-               ? json->source.position - json->linepos - json->lineadj
+               ? json->source.position == 0 ? 1 : json->source.position - json->linepos - json->lineadj
                : json->colno;
 }
 

--- a/tests/stream.c
+++ b/tests/stream.c
@@ -25,8 +25,9 @@ main(void)
     json_open_stream(s, stdin);
     json_set_streaming(s, 1);
     puts("struct expect seq[] = {");
+    enum json_type type;
     for (bool first = true;;) {
-        enum json_type type = json_next(s);
+        type = json_next(s);
         const char *value = 0;
         switch (type) {
             case JSON_NULL:
@@ -67,5 +68,7 @@ main(void)
             first = false;
     }
     puts("};");
+    if (type == JSON_ERROR)
+      fprintf(stderr, "error: %s\n", json_get_error(s));
     json_close(s);
 }


### PR DESCRIPTION
We have tested this against a fuzzer as well as with line/column tests in our own code (https://github.com/libstud/libstud-json/blob/master/tests/parser/basics/basics.testscript).