### PR TITLE
Improve portability to embedded platforms

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,19 +1,20 @@
 .POSIX:
 CC     = cc
-CFLAGS = -std=c99 -pedantic -Wall -Wextra -Wno-missing-field-initializers
+CFLAGS = -std=c99 -pedantic -Wall -Wextra -Wno-missing-field-initializers -I.
 
 all: tests/pretty tests/stream tests/tests
 
-tests/pretty: tests/pretty.o pdjson.o
-	$(CC) $(LDFLAGS) -o $@ tests/pretty.o pdjson.o $(LDLIBS)
+tests/pretty: tests/pretty.o pdjson.o pdjson_stream.o
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 tests/tests: tests/tests.o pdjson.o
-	$(CC) $(LDFLAGS) -o $@ tests/tests.o pdjson.o $(LDLIBS)
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
-tests/stream: tests/stream.o pdjson.o
-	$(CC) $(LDFLAGS) -o $@ tests/stream.o pdjson.o $(LDLIBS)
+tests/stream: tests/stream.o pdjson.o pdjson_stream.o
+	$(CC) $(LDFLAGS) -o $@ $^ $(LDLIBS)
 
 pdjson.o: pdjson.c pdjson.h
+pdjson_stream.o: pdjson_stream.c pdjson.h
 tests/pretty.o: tests/pretty.c pdjson.h
 tests/tests.o: tests/tests.c pdjson.h
 tests/stream.o: tests/stream.c pdjson.h

--- a/pdjson.c
+++ b/pdjson.c
@@ -831,10 +831,14 @@ const char *json_get_string(json_stream *json, size_t *length)
         return json->data.string;
 }
 
-double json_get_number(json_stream *json)
+json_number json_get_number(json_stream *json)
 {
     char *p = json->data.string;
+#ifndef PDJSON_WITHOUT_FLOAT
     return p == NULL ? 0 : strtod(p, NULL);
+#else
+    return p == NULL ? 0 : strtol(p, NULL, 10);
+#endif
 }
 
 const char *json_get_error(json_stream *json)

--- a/pdjson.c
+++ b/pdjson.c
@@ -105,19 +105,6 @@ static int buffer_get(struct json_source *source)
     return c;
 }
 
-static int stream_get(struct json_source *source)
-{
-    source->position++;
-    return fgetc(source->source.stream.stream);
-}
-
-static int stream_peek(struct json_source *source)
-{
-    int c = fgetc(source->source.stream.stream);
-    ungetc(c, source->source.stream.stream);
-    return c;
-}
-
 static void init(json_stream *json)
 {
     json->lineno = 1;
@@ -917,13 +904,6 @@ void json_open_string(json_stream *json, const char *string)
     json_open_buffer(json, string, strlen(string));
 }
 
-void json_open_stream(json_stream *json, FILE * stream)
-{
-    init(json);
-    json->source.get = stream_get;
-    json->source.peek = stream_peek;
-    json->source.source.stream.stream = stream;
-}
 
 static int user_get(struct json_source *json)
 {

--- a/pdjson.h
+++ b/pdjson.h
@@ -1,10 +1,6 @@
 #ifndef PDJSON_H
 #define PDJSON_H
 
-#ifndef PDJSON_SYMEXPORT
-#   define PDJSON_SYMEXPORT
-#endif
-
 #ifdef __cplusplus
 extern "C" {
 #else
@@ -20,95 +16,9 @@ extern "C" {
 #endif /* __cplusplus */
 
 #include <stdio.h>
+#include <pdjson_base.h>
 
-enum json_type {
-    JSON_ERROR = 1, JSON_DONE,
-    JSON_OBJECT, JSON_OBJECT_END, JSON_ARRAY, JSON_ARRAY_END,
-    JSON_STRING, JSON_NUMBER, JSON_TRUE, JSON_FALSE, JSON_NULL
-};
-
-struct json_allocator {
-    void *(*malloc)(size_t);
-    void *(*realloc)(void *, size_t);
-    void (*free)(void *);
-};
-
-typedef int (*json_user_io)(void *user);
-
-typedef struct json_stream json_stream;
-typedef struct json_allocator json_allocator;
-
-PDJSON_SYMEXPORT void json_open_buffer(json_stream *json, const void *buffer, size_t size);
-PDJSON_SYMEXPORT void json_open_string(json_stream *json, const char *string);
 PDJSON_SYMEXPORT void json_open_stream(json_stream *json, FILE *stream);
-PDJSON_SYMEXPORT void json_open_user(json_stream *json, json_user_io get, json_user_io peek, void *user);
-PDJSON_SYMEXPORT void json_close(json_stream *json);
-
-PDJSON_SYMEXPORT void json_set_allocator(json_stream *json, json_allocator *a);
-PDJSON_SYMEXPORT void json_set_streaming(json_stream *json, bool mode);
-
-PDJSON_SYMEXPORT enum json_type json_next(json_stream *json);
-PDJSON_SYMEXPORT enum json_type json_peek(json_stream *json);
-PDJSON_SYMEXPORT void json_reset(json_stream *json);
-PDJSON_SYMEXPORT const char *json_get_string(json_stream *json, size_t *length);
-PDJSON_SYMEXPORT double json_get_number(json_stream *json);
-
-PDJSON_SYMEXPORT enum json_type json_skip(json_stream *json);
-PDJSON_SYMEXPORT enum json_type json_skip_until(json_stream *json, enum json_type type);
-
-PDJSON_SYMEXPORT size_t json_get_lineno(json_stream *json);
-PDJSON_SYMEXPORT size_t json_get_position(json_stream *json);
-PDJSON_SYMEXPORT size_t json_get_depth(json_stream *json);
-PDJSON_SYMEXPORT enum json_type json_get_context(json_stream *json, size_t *count);
-PDJSON_SYMEXPORT const char *json_get_error(json_stream *json);
-
-PDJSON_SYMEXPORT int json_source_get(json_stream *json);
-PDJSON_SYMEXPORT int json_source_peek(json_stream *json);
-PDJSON_SYMEXPORT bool json_isspace(int c);
-
-/* internal */
-
-struct json_source {
-    int (*get)(struct json_source *);
-    int (*peek)(struct json_source *);
-    size_t position;
-    union {
-        struct {
-            FILE *stream;
-        } stream;
-        struct {
-            const char *buffer;
-            size_t length;
-        } buffer;
-        struct {
-            void *ptr;
-            json_user_io get;
-            json_user_io peek;
-        } user;
-    } source;
-};
-
-struct json_stream {
-    size_t lineno;
-
-    struct json_stack *stack;
-    size_t stack_top;
-    size_t stack_size;
-    enum json_type next;
-    unsigned flags;
-
-    struct {
-        char *string;
-        size_t string_fill;
-        size_t string_size;
-    } data;
-
-    size_t ntokens;
-
-    struct json_source source;
-    struct json_allocator alloc;
-    char errmsg[128];
-};
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/pdjson_base.h
+++ b/pdjson_base.h
@@ -5,6 +5,12 @@
 #   define PDJSON_SYMEXPORT
 #endif
 
+#ifndef PDJSON_WITHOUT_FLOAT
+typedef float json_number;
+#else
+typedef long json_number;
+#endif
+
 #ifndef EOF
 #  define EOF (-1)
 #endif
@@ -38,7 +44,7 @@ PDJSON_SYMEXPORT enum json_type json_next(json_stream *json);
 PDJSON_SYMEXPORT enum json_type json_peek(json_stream *json);
 PDJSON_SYMEXPORT void json_reset(json_stream *json);
 PDJSON_SYMEXPORT const char *json_get_string(json_stream *json, size_t *length);
-PDJSON_SYMEXPORT double json_get_number(json_stream *json);
+PDJSON_SYMEXPORT json_number json_get_number(json_stream *json);
 
 PDJSON_SYMEXPORT enum json_type json_skip(json_stream *json);
 PDJSON_SYMEXPORT enum json_type json_skip_until(json_stream *json, enum json_type type);

--- a/pdjson_base.h
+++ b/pdjson_base.h
@@ -1,0 +1,96 @@
+#ifndef PDJSON_BASE_H
+#define PDJSON_BASE_H
+
+#ifndef PDJSON_SYMEXPORT
+#   define PDJSON_SYMEXPORT
+#endif
+
+#ifndef EOF
+#  define EOF (-1)
+#endif
+
+enum json_type {
+    JSON_ERROR = 1, JSON_DONE,
+    JSON_OBJECT, JSON_OBJECT_END, JSON_ARRAY, JSON_ARRAY_END,
+    JSON_STRING, JSON_NUMBER, JSON_TRUE, JSON_FALSE, JSON_NULL
+};
+
+struct json_allocator {
+    void *(*malloc)(size_t);
+    void *(*realloc)(void *, size_t);
+    void (*free)(void *);
+};
+
+typedef int (*json_user_io)(void *user);
+
+typedef struct json_stream json_stream;
+typedef struct json_allocator json_allocator;
+
+PDJSON_SYMEXPORT void json_open_buffer(json_stream *json, const void *buffer, size_t size);
+PDJSON_SYMEXPORT void json_open_string(json_stream *json, const char *string);
+PDJSON_SYMEXPORT void json_open_user(json_stream *json, json_user_io get, json_user_io peek, void *user);
+PDJSON_SYMEXPORT void json_close(json_stream *json);
+
+PDJSON_SYMEXPORT void json_set_allocator(json_stream *json, json_allocator *a);
+PDJSON_SYMEXPORT void json_set_streaming(json_stream *json, bool mode);
+
+PDJSON_SYMEXPORT enum json_type json_next(json_stream *json);
+PDJSON_SYMEXPORT enum json_type json_peek(json_stream *json);
+PDJSON_SYMEXPORT void json_reset(json_stream *json);
+PDJSON_SYMEXPORT const char *json_get_string(json_stream *json, size_t *length);
+PDJSON_SYMEXPORT double json_get_number(json_stream *json);
+
+PDJSON_SYMEXPORT enum json_type json_skip(json_stream *json);
+PDJSON_SYMEXPORT enum json_type json_skip_until(json_stream *json, enum json_type type);
+
+PDJSON_SYMEXPORT size_t json_get_lineno(json_stream *json);
+PDJSON_SYMEXPORT size_t json_get_position(json_stream *json);
+PDJSON_SYMEXPORT size_t json_get_depth(json_stream *json);
+PDJSON_SYMEXPORT enum json_type json_get_context(json_stream *json, size_t *count);
+PDJSON_SYMEXPORT const char *json_get_error(json_stream *json);
+
+PDJSON_SYMEXPORT int json_source_get(json_stream *json);
+PDJSON_SYMEXPORT int json_source_peek(json_stream *json);
+PDJSON_SYMEXPORT bool json_isspace(int c);
+
+/* internal */
+struct json_source {
+    int (*get)(struct json_source *);
+    int (*peek)(struct json_source *);
+    size_t position;
+    union {
+        struct {
+            const char *buffer;
+            size_t length;
+        } buffer;
+        struct {
+            void *ptr;
+            json_user_io get;
+            json_user_io peek;
+        } user;
+    } source;
+};
+
+struct json_stream {
+    size_t lineno;
+
+    struct json_stack *stack;
+    size_t stack_top;
+    size_t stack_size;
+    enum json_type next;
+    unsigned flags;
+
+    struct {
+        char *string;
+        size_t string_fill;
+        size_t string_size;
+    } data;
+
+    size_t ntokens;
+
+    struct json_source source;
+    struct json_allocator alloc;
+    char errmsg[128];
+};
+
+#endif

--- a/pdjson_base.h
+++ b/pdjson_base.h
@@ -21,6 +21,11 @@ enum json_type {
     JSON_STRING, JSON_NUMBER, JSON_TRUE, JSON_FALSE, JSON_NULL
 };
 
+struct json_stack {
+    enum json_type type;
+    long count;
+};
+
 struct json_allocator {
     void *(*malloc)(size_t);
     void *(*realloc)(void *, size_t);
@@ -38,6 +43,8 @@ PDJSON_SYMEXPORT void json_open_user(json_stream *json, json_user_io get, json_u
 PDJSON_SYMEXPORT void json_close(json_stream *json);
 
 PDJSON_SYMEXPORT void json_set_allocator(json_stream *json, json_allocator *a);
+PDJSON_SYMEXPORT void json_set_static_memory(json_stream *json, struct json_stack *stack,
+					     size_t stack_size, char *string_buffer, size_t string_size);
 PDJSON_SYMEXPORT void json_set_streaming(json_stream *json, bool mode);
 
 PDJSON_SYMEXPORT enum json_type json_next(json_stream *json);

--- a/pdjson_stream.c
+++ b/pdjson_stream.c
@@ -1,0 +1,23 @@
+#include <stdlib.h>
+#include <stdio.h>
+
+#ifndef PDJSON_H
+#  include "pdjson.h"
+#endif
+
+static int stream_get(void *fd)
+{
+    return fgetc(fd);
+}
+
+static int stream_peek(void *fd)
+{
+    int c = fgetc(fd);
+    ungetc(c, fd);
+    return c;
+}
+
+void json_open_stream(json_stream *json, FILE * stream)
+{
+    json_open_user(json, stream_get, stream_peek, stream);
+}


### PR DESCRIPTION
I needed some json library to integrate in a custom u-boot and was happy to find a library with a nice API and properly constrained memory usage. But to integrate pdjson in such an environment a few changes were needed, mostly revolving around the fact that no full libc is available. In particular FILE and float are often not available on embedded platforms and malloc is often avoided.

This series is a first attempt at refactoring the code to make the core part easier to integrate in such limited environment. For this I moved the support for FILE stream to a dedicated C file and split the header file in two. The expectation is that platforms with special needs can provide their own `pdjson.h` that take care of providing all the required types and libc compatibility before including `pdjson_base.h` which provide the declarations for the core functionality.

There could be other ways to achieve the same goal but I tried to keep with the simple layout and lack of configure script. 