### PR TITLE
Add ClusterFuzzLite integration

### DIFF
--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,8 +1,6 @@
 FROM gcr.io/oss-fuzz-base/base-builder
-RUN apt-get update && apt-get install -y make autoconf automake libtool cmake \
-                      pkg-config curl check
+RUN apt-get update && apt-get install -y make autoconf automake libtool
 COPY . $SRC/pdjson
 COPY .clusterfuzzlite/build.sh $SRC/build.sh
-COPY .clusterfuzzlite/*.cpp $SRC/
 COPY .clusterfuzzlite/*.c $SRC/
 WORKDIR pdjson

--- a/.clusterfuzzlite/Dockerfile
+++ b/.clusterfuzzlite/Dockerfile
@@ -1,0 +1,8 @@
+FROM gcr.io/oss-fuzz-base/base-builder
+RUN apt-get update && apt-get install -y make autoconf automake libtool cmake \
+                      pkg-config curl check
+COPY . $SRC/pdjson
+COPY .clusterfuzzlite/build.sh $SRC/build.sh
+COPY .clusterfuzzlite/*.cpp $SRC/
+COPY .clusterfuzzlite/*.c $SRC/
+WORKDIR pdjson

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,9 +1,6 @@
 #!/bin/bash
-for file in "pdjson.c"; do
-  $CC $CFLAGS -c ${file}
-done
+$CC $CFLAGS -c pdjson.c
 
-rm -f ./test*.o
 llvm-ar rcs libfuzz.a *.o
 
 

--- a/.clusterfuzzlite/build.sh
+++ b/.clusterfuzzlite/build.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+for file in "pdjson.c"; do
+  $CC $CFLAGS -c ${file}
+done
+
+rm -f ./test*.o
+llvm-ar rcs libfuzz.a *.o
+
+
+$CC $CFLAGS $LIB_FUZZING_ENGINE $SRC/fuzzer.c -Wl,--whole-archive $SRC/pdjson/libfuzz.a -Wl,--allow-multiple-definition -I$SRC/pdjson/  -o $OUT/fuzzer

--- a/.clusterfuzzlite/fuzzer.c
+++ b/.clusterfuzzlite/fuzzer.c
@@ -1,0 +1,15 @@
+#include <stdlib.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "pdjson.h"
+
+int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {
+    json_stream stream;
+    json_open_buffer(&stream, (const char *)data, size);
+    json_skip(&stream);
+    json_close(&stream);
+    
+    return 0;
+}

--- a/.clusterfuzzlite/fuzzer.c
+++ b/.clusterfuzzlite/fuzzer.c
@@ -1,8 +1,4 @@
-#include <stdlib.h>
 #include <stdint.h>
-#include <stdio.h>
-#include <string.h>
-
 #include "pdjson.h"
 
 int LLVMFuzzerTestOneInput(const uint8_t *data, size_t size) {

--- a/.clusterfuzzlite/project.yaml
+++ b/.clusterfuzzlite/project.yaml
@@ -1,0 +1,1 @@
+language: c

--- a/.github/workflows/cflite_pr.yml
+++ b/.github/workflows/cflite_pr.yml
@@ -1,0 +1,30 @@
+name: ClusterFuzzLite PR fuzzing
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [ master ]
+permissions: read-all
+jobs:
+  PR:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        sanitizer: [address]
+    steps:
+    - name: Build Fuzzers (${{ matrix.sanitizer }})
+      id: build
+      uses: google/clusterfuzzlite/actions/build_fuzzers@v1
+      with:
+        sanitizer: ${{ matrix.sanitizer }}
+        language: c++
+        bad-build-check: false
+    - name: Run Fuzzers (${{ matrix.sanitizer }})
+      id: run
+      uses: google/clusterfuzzlite/actions/run_fuzzers@v1
+      with:
+        github-token: ${{ secrets.GITHUB_TOKEN }}
+        fuzz-seconds: 100
+        mode: 'code-change'
+        report-unreproducible-crashes: false
+        sanitizer: ${{ matrix.sanitizer }}


### PR DESCRIPTION
This adds fuzzing by way of [ClusterFuzzLite](https://google.github.io/clusterfuzzlite/), which is a GitHub action that will perform a short amount of fuzzing for new PRs. The goal is to use fuzzing to catch bugs that may be introduced by new PRs.

If you'd like to test this the way ClusterFuzzLite runs it (by way of OSS-Fuzz) you can use the steps:

```sh
git clone https://github.com/google/oss-fuzz
git clone https://github.com/DavidKorczynski/pdjson
cd pdjson
git checkout cflite

# Build the fuzzers in .clusterfuzzlite
python3 ../oss-fuzz/infra/helper.py build_fuzzers --external $PWD

# Run the fuzzer for 10 seconds
python3 ../oss-fuzz/infra/helper.py run_fuzzer --external $PWD fuzzer -- -max_total_time=10
```